### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,4 +4,5 @@ author=Hong-She Liang <starofrainnight@gmail.com>
 maintainer=Hong-She Liang <starofrainnight@gmail.com>
 sentence=A gettext like u8glib helper library for arduino
 paragraph=
+category=Display
 url=https://github.com/starofrainnight/ArduinoU8Gettext


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library U8Gettext is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format